### PR TITLE
Mubsub: Add back recreate and retryInterval options

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -29,6 +29,13 @@ function Channel(connection, name, options) {
     this.listening = null;
     this.name = name || 'mubsub';
 
+    this.recreate = options.recreate || true;
+    this.retryInterval = options.retryInterval || 200;
+
+    // delete recreate. retryInterval field so that monog does not throw an error
+    delete options.recreate;
+    delete options.retryInterval;
+
     this.create().listen();
     this.setMaxListeners(0);
 }
@@ -145,9 +152,9 @@ Channel.prototype.listen = function (latest) {
                         tailable: true,
                         awaitData: true,
                         timeout: false,
-                        sortValue: {$natural: -1}, 
-                        numberOfRetries: Number.MAX_VALUE, 
-                        tailableRetryInterval: self.options.retryInterval
+                        sortValue: {$natural: -1},
+                        numberOfRetries: Number.MAX_VALUE,
+                        tailableRetryInterval: self.retryInterval
                     }
                 );
 
@@ -157,7 +164,7 @@ Channel.prototype.listen = function (latest) {
             if (!doc) {
                 return setTimeout(function () {
                     self.emit('error', new Error('Mubsub: broken cursor.'));
-                    if (self.options.recreate) {
+                    if (self.recreate) {
                         self.create().listen(latest);
                     }
                 }, 1000);


### PR DESCRIPTION
## Description

The documentation of the library mentions the following defaults:
- recreate: true (for channel)
- retryInterval: 200 (for collection find)

However, looking at the code, it looks like these values are undefined by default. Long back in this PR https://github.com/scttnlsn/mubsub/pull/55, the defaults were removed.

(This PR brings these back)

## Background and few concerns
    
How is the library expected to behave with its current implementation of the above defaults ?
1. Since recreate is undefined, the cursor will never be recreated on error ?
2. What is the default value for tailableRetryInterval, and how does the current implementation of the library affect it ? Because it is being passed as null right now.

We use this adapter https://www.npmjs.com/package/@nodebb/socket.io-adapter-mongo, for being able to run multiple socket.io instances in different processes or servers that can all broadcast and emit events to and from each other.
This adapter internally uses nodebb mubsub.
We have seen issues where the flow of messages stops once mongo disconnects or if there is a topology change event.
Could this be because the recreate/retryInterval options are undefined ?
I understand that the mongo client internally used by mubsub does auto reconnect by default. But since it does not set reconnect attempts, the default attempts are 30 with a retry interval of 1s. 
Do we need to change this ?