### PR TITLE
Update mongodb driver to 4.x and CI to use node >12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 node_js:
-  - "10"
-  - "8"
-  - "6"
-  - "5"
-  - "4"
+  - "16"
+  - "14"
+  - "12"
 script: "npm test"
 services:
   - mongodb

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -61,7 +61,10 @@ Channel.prototype.publish = function (event, message, callback) {
     this.ready(function (collection) {
         collection.insertOne({ event: event, message: message }, options, function (err, docs) {
             if (err) return callback(err);
-            callback(null, docs.ops[0]);
+            collection.findOne({_id: docs.insertedId}, function (err, doc) {
+                if (err) return callback(err);
+                callback(err, doc);
+            })
         });
     });
 
@@ -210,7 +213,11 @@ Channel.prototype.latest = function (latest, callback) {
 
                 collection.insertOne({ 'dummy': true }, { safe: true }, function (err, docs) {
                     if (err) return cb(err);
-                    callback(err, docs.ops[0], collection);
+                    collection.findOne({_id: docs.insertedId}, function (err, doc) {
+                        if (err) return cb(err);
+                        callback(err, doc, collection);
+                    })
+                    
                 });
             });
     }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -14,7 +14,6 @@ function Connection(uri, options) {
     var self = this;
 
     options || (options = {});
-    options.autoReconnect != null || (options.autoReconnect = true);
 
     // It's a Db instance.
     if (uri.collection) {
@@ -25,7 +24,7 @@ function Connection(uri, options) {
             self.client = client;
             self.db = client.db();
             self.emit('connect', self.db);
-            self.db.on('error', function (err) {
+            self.client.on('error', function (err) {
                 self.emit('error', err);
             });
         });
@@ -54,8 +53,8 @@ Object.defineProperty(Connection.prototype, 'state', {
         if (this.destroyed) {
             state = 'destroyed';
         }
-        else if (this.db) {
-            state = this.db.serverConfig.isConnected()
+        else if (this.client) {
+            state = this.client.topology.isConnected()
                 ? 'connected' : 'disconnected';
         } else {
             state = 'connecting';

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "mongodb": "^4.1.3"
   },
   "devDependencies": {
-    "mocha": "^2.2.5"
+    "mocha": "^9.1.3"
   },
   "scripts": {
-    "test": "mocha test --timeout 10000",
+    "test": "mocha --timeout 10000 --exit",
     "publish": "git push origin && git push origin --tags",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "git://github.com/NodeBB/mubsub.git"
   },
   "dependencies": {
-    "mongodb": "^3.6.0"
+    "mongodb": "^4.1.3"
   },
   "devDependencies": {
     "mocha": "^2.2.5"

--- a/test/connection.js
+++ b/test/connection.js
@@ -4,7 +4,7 @@ var helpers = require('./helpers');
 
 describe('Connection', function () {
     it('emits "error" event', function (done) {
-        mubsub('mongodb://localhost:6666/mubsub_tests').on('error', function () {
+        mubsub('mongodb://localhost:6666/mubsub_tests', {serverSelectionTimeoutMS: 1000}).on('error', function () {
             done();
         });
     });


### PR DESCRIPTION
Updates some code to make it work with current mongodb driver, and also the CI configuration to use current Node LTS releases (and mocha version).

Doing this small update while working on re-adding mongo support for clustering in NodeBB.